### PR TITLE
Refresh each datastore info at every scrape

### DIFF
--- a/vmware_exporter.py
+++ b/vmware_exporter.py
@@ -314,6 +314,7 @@ class VMWareMetricsResource(Resource):
         Get Datastore information
         """
         for ds in self._vmware_get_obj(content, [vim.Datastore]):
+            ds.RefreshDatastoreStorageInfo()
             summary = ds.summary
             ds_capacity = summary.capacity
             ds_freespace = summary.freeSpace


### PR DESCRIPTION
Refresh each datastore info at every scrape to report real time disk capacity.

I just recently ran into a situation where several VMs that were all on the same datastore paused because the datastore was full. I am not using these esxi hosts with vcenter so the only monitoring I have is prometheus. Looking at the prometheus metrics of the datastore capacity shows the capacity jump from 20% full to 100% in one scrape interval.
With this change I can now see the real time capacity changes.