### PR TITLE
requirements: add service-identity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytz
 pyvmomi>=6.5
 twisted>=14.0.2
 yamlconfig
+service-identity


### PR DESCRIPTION
Removes a warning:

UserWarning: You do not have a working installation of the service_identity module: 'No module named service_identity'.  Please install it from <https://pypi.python.org/pypi/service_identity\> and make sure all of its dependencies are satisfied.  Without the service_identity module, Twisted can perform only rudimentary TLS client hostname verification.  Many valid certificate/hostname mappings may be rejected.
Error, cannot read configuration file