### PR TITLE
Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:2-slim
+
+WORKDIR /usr/src/app
+
+RUN buildDeps="gcc python-dev" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends $buildDeps \
+ && pip install --no-cache-dir vmware_exporter \
+ && SUDO_FORCE_REMOVE=yes \
+ && apt-get purge -y --auto-remove \
+                  -o APT::AutoRemove::RecommendsImportant=false \
+                  $buildDeps \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 9272
+
+ENTRYPOINT ["vmware_exporter"]


### PR DESCRIPTION
Added Dockerfile based on `python:2-slim`

Usage example:
```
$ docker run --rm -d --name vmware-exporter -v /path/to/config.yml:/etc/vmware-exporter/config.yml -p 9272:9272 <image name> -c /etc/vmware-exporter/config.yml
```

Note: I tried to build using Python3, however when trying to scrape I get "No target defined" error:
```
$ curl -v "http://localhost:9272/metrics?target=<vcenter host>"
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 9272 (#0)
> GET /metrics?target=<vcenter host> HTTP/1.1
> User-Agent: curl/7.38.0
> Host: localhost:9272
> Accept: */*
>
< HTTP/1.1 404 Not Found
* Server TwistedWeb/17.9.0 is not blacklisted
< Server: TwistedWeb/17.9.0
< Date: Fri, 09 Feb 2018 17:45:09 GMT
< Content-Type: text/plain; charset=UTF-8
< Content-Length: 19
<
No target defined
* Connection #0 to host localhost left intact
```

The same works fine with Python2.