### PR TITLE
limit what data is collected via the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ Get VMWare VCenter information:
 
 Alternatively, if you don't wish to install the package, run using `$ vmware_exporter/vmware_exporter.py`
 
+### Limiting data collection
+
+Large installations may have trouble collecting all of the data in a timely fashion,
+so you can limit which subsystems are collected by adding a
+`collect_only` argument the config section, e.g. under `default`:
+
+    collect_only:
+    #   - vms
+      - datastores
+      - hosts
+
+would skip collecting information on the VMs. If there is no `collect_only`
+argument, everything will be collected as normal.
+
 ### Prometheus configuration
 
 You can use the following parameters in prometheus configuration file. The `params` section is used to manage multiple login/passwords.

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -7,3 +7,12 @@ esx:
     vmware_user: 'root'
     vmware_password: 'password'
     ignore_ssl: True
+
+limited:
+    vmware_user: 'administrator@vsphere.local'
+    vmware_password: 'password'
+    ignore_ssl: True
+    collect_only:
+    #   - vms
+      - datastores
+      - hosts

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -179,13 +179,6 @@ class VMWareMetricsResource(Resource):
         for s in collect_subsystems:
             metrics.update(metric_list[s])
 
-
-        collect_subsystems = self._collect_subsystems(section, metric_list.keys())
-
-        metrics = {}
-        for s in collect_subsystems:
-            metrics.update(metric_list[s])
-
         print("[{0}] Start collecting vcenter metrics for {1}".format(datetime.utcnow().replace(tzinfo=pytz.utc), target))
 
         self.si = self._vmware_connect(target, section)
@@ -230,29 +223,6 @@ class VMWareMetricsResource(Resource):
 
         for metricname, metric in metrics.items():
             yield metric
-
-    def _collect_subsystems(self, section, valid_subsystems):
-        """
-          Return the list of subsystems to collect - everything by default, a
-          subset if the config section has collect_only specified
-        """
-        collect_subsystems = []
-
-        if not self.config[section].get('collect_only'):
-            collect_subsystems = valid_subsystems
-        else:
-            for subsystem in self.config[section].get('collect_only'):
-                if subsystem in valid_subsystems:
-                    collect_subsystems.append(subsystem)
-                else:
-                    print("invalid subsystem specified in collect_only: " + str(subsystem))
-
-            if not collect_subsystems:
-                print("no valid subystems specified in collect_only, collecting everything")
-                collect_subsystems = valid_subsystems
-
-        return collect_subsystems
-
 
     def _collect_subsystems(self, section, valid_subsystems):
         """

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -97,7 +97,8 @@ class VMWareMetricsResource(Resource):
         if section not in self.config.keys():
             print("{} is not a valid section, using default".format(section))
             section='default'
-        metrics = {
+        metric_list ={}
+        metric_list['vms'] = {
                     'vmware_vm_power_state': GaugeMetricFamily(
                         'vmware_vm_power_state',
                         'VMWare VM Power state (On / Off)',
@@ -117,7 +118,9 @@ class VMWareMetricsResource(Resource):
                     'vmware_vm_num_cpu': GaugeMetricFamily(
                         'vmware_vm_num_cpu',
                         'VMWare Number of processors in the virtual machine',
-                        labels=['vm_name']),
+                        labels=['vm_name'])
+                    }
+        metric_list['datastores'] = {
                     'vmware_datastore_capacity_size': GaugeMetricFamily(
                         'vmware_datastore_capacity_size',
                         'VMWare Datasore capacity in bytes',
@@ -141,7 +144,9 @@ class VMWareMetricsResource(Resource):
                     'vmware_datastore_vms': GaugeMetricFamily(
                         'vmware_datastore_vms',
                         'VMWare Virtual Machines number using this datastore',
-                        labels=['ds_name']),
+                        labels=['ds_name'])
+                        }
+        metric_list['hosts'] = {
                     'vmware_host_power_state': GaugeMetricFamily(
                         'vmware_host_power_state',
                         'VMWare Host Power state (On / Off)',
@@ -168,6 +173,12 @@ class VMWareMetricsResource(Resource):
                         labels=['host_name']),
                 }
 
+        collect_subsystems = self._collect_subsystems(section, metric_list.keys())
+
+        metrics = {}
+        for s in collect_subsystems:
+            metrics.update(metric_list[s])
+
         print("[{0}] Start collecting vcenter metrics for {1}".format(datetime.utcnow().replace(tzinfo=pytz.utc), target))
 
         self.si = self._vmware_connect(target, section)
@@ -177,28 +188,31 @@ class VMWareMetricsResource(Resource):
 
         content = self.si.RetrieveContent()
 
-        # Get performance metrics counter information
-        counter_info = self._vmware_perf_metrics(content)
+        if 'vms' in collect_subsystems:
+            # Get performance metrics counter information
+            counter_info = self._vmware_perf_metrics(content)
 
-        # Fill Snapshots (count and age)
-        vm_counts, vm_ages = self._vmware_get_snapshots(content)
-        for v in vm_counts:
-            metrics['vmware_vm_snapshots'].add_metric([v['vm_name']],
-                                                            v['snapshot_count'])
-        for vm_age in vm_ages:
-            for v in vm_age:
-                metrics['vmware_vm_snapshot_timestamp_seconds'].add_metric([v['vm_name'],
-                                        v['vm_snapshot_name']],
-                                        v['vm_snapshot_timestamp_seconds'])
+            # Fill VM Informations
+            self._vmware_get_vms(content, metrics, counter_info)
+
+            # Fill Snapshots (count and age)
+            vm_counts, vm_ages = self._vmware_get_snapshots(content)
+            for v in vm_counts:
+                metrics['vmware_vm_snapshots'].add_metric([v['vm_name']],
+                                                                v['snapshot_count'])
+            for vm_age in vm_ages:
+                for v in vm_age:
+                    metrics['vmware_vm_snapshot_timestamp_seconds'].add_metric([v['vm_name'],
+                                            v['vm_snapshot_name']],
+                                            v['vm_snapshot_timestamp_seconds'])
 
         # Fill Datastore
-        self._vmware_get_datastores(content, metrics)
-
-        # Fill VM Informations
-        self._vmware_get_vms(content, metrics, counter_info)
+        if 'datastores' in collect_subsystems:
+            self._vmware_get_datastores(content, metrics)
 
         # Fill Hosts Informations
-        self._vmware_get_hosts(content, metrics)
+        if 'hosts' in collect_subsystems:
+            self._vmware_get_hosts(content, metrics)
 
         print("[{0}] Stop collecting vcenter metrics for {1}".format(datetime.utcnow().replace(tzinfo=pytz.utc), target))
 
@@ -209,6 +223,27 @@ class VMWareMetricsResource(Resource):
 
 
 
+    def _collect_subsystems(self, section, valid_subsystems):
+        """
+          Return the list of subsystems to collect - everything by default, a
+          subset if the config section has collect_only specified
+        """
+        collect_subsystems = []
+
+        if not self.config[section].get('collect_only'):
+            collect_subsystems = valid_subsystems
+        else:
+            for subsystem in self.config[section].get('collect_only'):
+                if subsystem in valid_subsystems:
+                    collect_subsystems.append(subsystem)
+                else:
+                    print("invalid subsystem specified in collect_only: " + str(subsystem))
+
+            if not collect_subsystems:
+                print("no valid subystems specified in collect_only, collecting everything")
+                collect_subsystems = valid_subsystems
+
+        return collect_subsystems
 
     def _to_unix_timestamp(self, my_date):
         return ((my_date - datetime(1970,1,1,tzinfo=pytz.utc)).total_seconds())

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -198,15 +198,15 @@ class VMWareMetricsResource(Resource):
             self._vmware_get_vms(content, metrics, counter_info)  
 
             # Fill Snapshots (count and age)  
-           vm_counts, vm_ages = self._vmware_get_snapshots(content)  
-           for v in vm_counts:  
-               metrics['vmware_vm_snapshots'].add_metric([v['vm_name']],  
-                                                               v['snapshot_count'])  
-           for vm_age in vm_ages:  
-               for v in vm_age:  
-                   metrics['vmware_vm_snapshot_timestamp_seconds'].add_metric([v['vm_name'],  
-                                           v['vm_snapshot_name']],  
-                                           v['vm_snapshot_timestamp_seconds'])  
+            vm_counts, vm_ages = self._vmware_get_snapshots(content)  
+            for v in vm_counts:  
+                metrics['vmware_vm_snapshots'].add_metric([v['vm_name']],  
+                                                                v['snapshot_count'])  
+            for vm_age in vm_ages:  
+                for v in vm_age:  
+                    metrics['vmware_vm_snapshot_timestamp_seconds'].add_metric([v['vm_name'],  
+                                            v['vm_snapshot_name']],  
+                                            v['vm_snapshot_timestamp_seconds'])  
 
 
         # Fill Datastore  
@@ -225,7 +225,7 @@ class VMWareMetricsResource(Resource):
         for metricname, metric in metrics.items():
             yield metric
 
- def _collect_subsystems(self, section, valid_subsystems):  
+    def _collect_subsystems(self, section, valid_subsystems):  
         """  
           Return the list of subsystems to collect - everything by default, a  
           subset if the config section has collect_only specified  


### PR DESCRIPTION
I've got the same issue as #27 - we're way too large to gather all the VM info in a timely fashion.  

Added support for an optional `collect_only` setting for the config, which will limit collecting to any combination of 'vms', 'datastores' and/or 'hosts'.  Will fall-back to collecting everything if no `collect_only` specified or if it's not valid.

