### PR TITLE
vmware_dc_cluster_host_vm_info metric

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pytz
 pyvmomi>=6.5
 twisted>=14.0.2
 yamlconfig
+pyasn1
 service-identity

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -175,7 +175,7 @@ class VMWareMetricsResource(Resource):
         metric_list['metadata'] = {
                     'vmware_dc_cluster_host_vm_info': GaugeMetricFamily(
                         'vmware_dc_cluster_host_vm_info',
-                        'VMWare datacenter, cluster, host and vm info',
+                        'VMWare datacenter cluster host and vm info',
                         labels=['dc_name', 'cluster_name', 'host_name', 'vm_name']),
                 }
         collect_subsystems = self._collect_subsystems(section, metric_list.keys())
@@ -477,7 +477,7 @@ class VMWareMetricsResource(Resource):
 
     def _vmware_get_metadata(self, content, metadata_metrics):
         """
-        Get Metadata (Datacenter, cluster) information for hosts and VMs
+        Get Metadata (datacenter, cluster) information for hosts and VMs
         """
 
         children = content.rootFolder.childEntity

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -172,6 +172,12 @@ class VMWareMetricsResource(Resource):
                         'VMWare Host Memory Max availability in Mbytes',
                         labels=['host_name']),
                 }
+        metric_list['metadata'] = {
+                    'vmware_dc_cluster_host_vm_info': GaugeMetricFamily(
+                        'vmware_dc_cluster_host_vm_info',
+                        'VMWare datacenter, cluster, host and vm info',
+                        labels=['dc_name', 'cluster_name', 'host_name', 'vm_name']),
+                }
         collect_subsystems = self._collect_subsystems(section, metric_list.keys())
 
 
@@ -215,6 +221,10 @@ class VMWareMetricsResource(Resource):
         # Fill Hosts Informations
         if 'hosts' in collect_subsystems:
             self._vmware_get_hosts(content, metrics)
+	
+	# Collect cluster metadata
+	if 'metadata' in collect_subsystems:
+	    self._vmware_get_metadata(content, metrics)
 
 
         print("[{0}] Stop collecting vcenter metrics for {1}".format(datetime.utcnow().replace(tzinfo=pytz.utc), target))
@@ -463,6 +473,25 @@ class VMWareMetricsResource(Resource):
                                         summary.quickStats.overallMemoryUsage)
                 host_metrics['vmware_host_memory_max'].add_metric([host.name],
                             float(summary.hardware.memorySize) / 1024 / 1024)
+
+
+    def _vmware_get_metadata(self, content, metadata_metrics):
+        """
+        Get Metadata (Datacenter, cluster) information for hosts and VMs
+        """
+
+        children = content.rootFolder.childEntity
+        for child in children:  # Iterate though DataCenters
+            dc = child
+            clusters = dc.hostFolder.childEntity
+            for cluster in clusters:  # Iterate through the clusters in the DC
+                hosts = cluster.host
+                for host in hosts:  # Iterate through Hosts in the Cluster
+                    host_name = host.summary.config.name
+                    vms = host.vm
+                    for vm in vms:  # Iterate through each VM on the host
+                        vm_name = vm.summary.config.name
+                        metadata_metrics['vmware_dc_cluster_host_vm_info'].add_metric([dc.name, cluster.name, host_name, vm_name], 1)
 
 
 def main():

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -222,10 +222,9 @@ class VMWareMetricsResource(Resource):
         if 'hosts' in collect_subsystems:
             self._vmware_get_hosts(content, metrics)
 	
-	# Collect cluster metadata
-	if 'metadata' in collect_subsystems:
-	    self._vmware_get_metadata(content, metrics)
-
+        # Collect cluster metadata
+        if 'metadata' in collect_subsystems:
+            self._vmware_get_metadata(content, metrics)
 
         print("[{0}] Stop collecting vcenter metrics for {1}".format(datetime.utcnow().replace(tzinfo=pytz.utc), target))
 


### PR DESCRIPTION
This (partially) fixes https://github.com/rverchere/vmware_exporter/issues/28

This metric provides labels of the datacenters, clusters, hosts and vms

For example:
```
vmware_dc_cluster_host_vm_info{cluster_name="PROD",dc_name="SITE-A",host_name="esx-prod-1.foo.bar",vm_name="foo-vm-1"} 1.0
```

This metric can be combined to filter subset of the other metrics based on the above labels.
